### PR TITLE
Don't overwrite files if nothing has changed

### DIFF
--- a/Source/FindAndReplace/FindAndReplaceManager.cs
+++ b/Source/FindAndReplace/FindAndReplaceManager.cs
@@ -39,10 +39,10 @@ namespace FindAndReplace
 
                 if (newContent != content)
                 {
-					if (!Arguments.IsDemoMode)
-					{
-						File.WriteAllText(filename, newContent);
-					}
+                    if (!Arguments.IsDemoMode)
+                    {
+                        File.WriteAllText(filename, newContent);
+                    }
 
                     this.FilesMatched.Add(relativeFile);
                     Logger?.Invoke(relativeFile, newContent); 

--- a/Source/FindAndReplace/FindAndReplaceManager.cs
+++ b/Source/FindAndReplace/FindAndReplaceManager.cs
@@ -37,13 +37,13 @@ namespace FindAndReplace
 
                 string newContent = Regex.Replace(content, Arguments.Find, Arguments.Replace, RegexOptions.IgnoreCase);
 
-                if (!Arguments.IsDemoMode)
-                {
-                    File.WriteAllText(filename, newContent);
-                }
-
                 if (newContent != content)
                 {
+					if (!Arguments.IsDemoMode)
+					{
+						File.WriteAllText(filename, newContent);
+					}
+
                     this.FilesMatched.Add(relativeFile);
                     Logger?.Invoke(relativeFile, newContent); 
                 }


### PR DESCRIPTION
Currently all files that match the pattern are written to disk, even if the content didn't change. This is unnecessary and changes the file's timestamps.

I suggest that files should only be re-written if the content has actually changed.