### PR TITLE
Preserve bom

### DIFF
--- a/Source/FindAndReplace/FindAndReplaceManager.cs
+++ b/Source/FindAndReplace/FindAndReplaceManager.cs
@@ -37,13 +37,13 @@ namespace FindAndReplace
 
                 string newContent = Regex.Replace(content, Arguments.Find, Arguments.Replace, RegexOptions.IgnoreCase);
 
-                if (!Arguments.IsDemoMode)
-                {
-                    File.WriteAllText(filename, newContent);
-                }
-
                 if (newContent != content)
                 {
+					if (!Arguments.IsDemoMode)
+					{
+						File.WriteAllText(filename, newContent);
+					}
+
                     this.FilesMatched.Add(relativeFile);
                     Logger?.Invoke(relativeFile, newContent); 
                 }


### PR DESCRIPTION
Currently all files are written with UTF-8 encoding without BOM. The original encoding and the BOM (if it existed) gets lost.

In this pull request I use the StreamReader to detected the actual encoding of the file. But the StreamReader doesn't have a property to show if the file actually had a BOM. So I try to detect the existence of a BOM by examining the first byte of the file. Only the most common BOMs are detected.
